### PR TITLE
[configure] use $SNAP_INSTANCE_NAME when talking to snapctl

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -10,4 +10,4 @@ if [ ! -e "$SNAP/apps/${app}" ]; then
     exit 1
 fi
 
-snapctl restart $SNAP_NAME
+snapctl restart $SNAP_INSTANCE_NAME


### PR DESCRIPTION
This way you can `snap install mir-kiosk-apps_two` and have a parallel
installation :)