### PR TITLE
When running as a daemon, always restart

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,7 +10,7 @@ apps:
   daemon:
     command: run-daemon wayland-launch "$SNAP/apps/$(snapctl get app)"
     daemon: simple
-    restart-condition: on-failure
+    restart-condition: always
 
   mir-kiosk-apps:
     command: wayland-launch "$SNAP/apps/$(snapctl get app)"


### PR DESCRIPTION
When running as a daemon, always restart.

Made possible by the recent update to mir-kiosk-snap-launch.