### PR TITLE
kiosk launch update & GHA to build

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,0 +1,35 @@
+name: Snap
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  Snap:
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 30
+
+    steps:
+    - name: Install Snapcraft
+      uses: samuelmeuli/action-snapcraft@v1
+      with:
+        snapcraft_token: ${{ secrets.SNAPCRAFT_TOKEN }}
+        use_lxd: true
+
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Build and verify the snap
+      env:
+        SNAPCRAFT_BUILD_INFO: 1
+        SNAP_ENFORCE_RESQUASHFS: 0
+      run: |
+        sg lxd -c '/snap/bin/snapcraft --use-lxd'
+
+        sudo snap install review-tools
+        /snap/bin/review-tools.snap-review *.snap
+
+    - name: Publish the snap
+      run: |
+        snapcraft upload *.snap --release "edge/pr${{ github.event.number }}"

--- a/app-wrappers/bin/app-launcher
+++ b/app-wrappers/bin/app-launcher
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec ${SNAP}/"apps/$(snapctl get app)"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,12 +8,17 @@ base: core18
 
 apps:
   daemon:
-    command: run-daemon wayland-launch "$SNAP/apps/$(snapctl get app)"
+    command-chain:
+      - bin/run-daemon
+      - bin/wayland-launch
+    command: bin/app-launcher
     daemon: simple
     restart-condition: always
 
   mir-kiosk-apps:
-    command: wayland-launch "$SNAP/apps/$(snapctl get app)"
+    command-chain:
+      - bin/wayland-launch
+    command: bin/app-launcher
 
 plugs:
   network:
@@ -58,7 +63,7 @@ parts:
       - qml-module-qt-labs-folderlistmodel #Another missing dep, needed by photosurface
       - qml-module-qtquick-controls #Missing dep, needed by photoviewer
     organize:
-      usr/lib/*/qt5/examples/quick/demos: qt-demos
+      usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/qt5/examples/quick/demos: qt-demos
 
   qmldemo:
     plugin: dump
@@ -85,6 +90,8 @@ parts:
       echo "snapctl set app=rssnews" >> $SNAPCRAFT_PART_BUILD/meta/hooks/install
       echo "[ -e \"\$SNAP/apps/\$(snapctl get app)\" ] || snapctl set app=rssnews" >> $SNAPCRAFT_PART_BUILD/meta/hooks/post-refresh
       $SNAPCRAFT_PART_BUILD/build-with-plugs.sh network opengl wayland
+    stage-packages:
+      - inotify-tools
 
   app-wrappers:
     plugin: dump

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,7 +4,7 @@ summary: Example apps to run with mir-kiosk
 description: Example apps to run with mir-kiosk
 confinement: strict
 grade: devel
-base: core18
+base: core18  # DO NOT change this to core20! (Or be prepared to rework the examples and launch code)
 
 apps:
   daemon:


### PR DESCRIPTION
NB, not moved to `base: core20` as the Qt examples have changed